### PR TITLE
Update maintainer contact address for CRAN compliance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,14 @@
 Package: Racmacs
 Type: Package
 Title: Antigenic Cartography Macros
-Version: 1.2.9
-Date: 2023-11-30
-Authors@R: 
+Version: 1.2.10
+Date: 2026-07-07
+Authors@R:
   c(person(given = "Sam",
            family = "Wilks",
            role = c("aut", "cre"),
-           email = "sw463@cam.ac.uk"))
+           email = "sam.wilks@unimelb.edu.au",
+           comment = "University of Melbourne, Melbourne, Australia"))
 Description: A toolkit for making antigenic maps from immunological assay data,
     in order to quantify and visualize antigenic differences between different
     pathogen strains as described in


### PR DESCRIPTION
## Summary
- CRAN reported the maintainer email (`sw463@cam.ac.uk`) is bouncing and requested a fixed release (see https://cran.r-project.org/web/checks/check_results_Racmacs.html — all platform checks otherwise currently pass, so this is the only required change).
- Updates Sam Wilks's contact to his current University of Melbourne address (`sam.wilks@unimelb.edu.au`) and adds his affiliation.
- Bumps `Version` to 1.2.10 and `Date` for resubmission to CRAN.

Closes #181

## Test plan
- [x] `R CMD check` / `devtools::check()` still passes (0 errors, 0 warnings, 0 notes)
- [ ] Resubmit to CRAN after merge